### PR TITLE
add line 30 in pyTask1 to delete the leading underscore if the string…

### DIFF
--- a/modules/pyTask1.nf
+++ b/modules/pyTask1.nf
@@ -27,6 +27,7 @@ process pyTask1 {
         gn = re.sub('.*-\.-', '', top_hit)
         cells = gn.split()
         acell = cells[0]
+        acell=acell.lstrip("_")   # delete the leading underscore if the string begin with "_"
         agn = re.split('^([^_]*_[^_]*)(_|\.).*$', acell)[1]
         genus = agn.split('_')[0]
         species = agn.split('_')[1]


### PR DESCRIPTION
A bug was fixed in Sanibel. 

In most cases, the genus name generated by Mash begins with a letter. However, in rare cases, the genus name begins with an underscore (e.g. _Cellvibrio...). When the genus name begins with an underscore, the pipeline will not correctly truncate the genus and species names. This can cause subsequent processes (Prokka) to fail.